### PR TITLE
Allow to override `authorize_endpoint_class` also on POST requests

### DIFF
--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -169,7 +169,7 @@ class AuthorizeView(View):
             return redirect(uri)
 
     def post(self, request, *args, **kwargs):
-        authorize = AuthorizeEndpoint(request)
+        authorize = self.authorize_endpoint_class(request)
 
         try:
             authorize.validate_params()


### PR DESCRIPTION
Makes `authorize_endpoint_class` overridable.