### PR TITLE
Authorization codes MUST be single-use

### DIFF
--- a/oidc_provider/lib/endpoints/token.py
+++ b/oidc_provider/lib/endpoints/token.py
@@ -3,7 +3,7 @@ from base64 import urlsafe_b64encode
 import hashlib
 import logging
 from django.contrib.auth import authenticate
-
+from django.db import DatabaseError
 from django.http import JsonResponse
 
 from oidc_provider.lib.errors import (
@@ -70,7 +70,10 @@ class TokenEndpoint(object):
                 raise TokenError('invalid_client')
 
             try:
-                self.code = Code.objects.get(code=self.params['code'])
+                self.code = Code.objects.select_for_update(nowait=True).get(code=self.params['code'])
+            except DatabaseError:
+                logger.debug('[Token] Code cannot be reused: %s', self.params['code'])
+                raise TokenError('invalid_grant')
             except Code.DoesNotExist:
                 logger.debug('[Token] Code does not exist: %s', self.params['code'])
                 raise TokenError('invalid_grant')

--- a/oidc_provider/tests/cases/test_token_endpoint.py
+++ b/oidc_provider/tests/cases/test_token_endpoint.py
@@ -4,6 +4,8 @@ import uuid
 
 from base64 import b64encode
 
+from django.db import DatabaseError
+
 try:
     from urllib.parse import urlencode
 except ImportError:
@@ -294,6 +296,24 @@ class TokenTestCase(TestCase):
         self.assertEqual(response_dic['expires_in'], 720)
         self.assertEqual(id_token['sub'], str(self.user.id))
         self.assertEqual(id_token['aud'], self.client.client_id)
+
+    @override_settings(OIDC_TOKEN_EXPIRE=720)
+    def test_authorization_code_cant_be_reused(self):
+        """
+        Authorization codes MUST be short lived and single-use,
+        as described in Section 10.5 of OAuth 2.0 [RFC6749].
+        """
+        code = self._create_code()
+        post_data = self._auth_code_post_data(code=code.code)
+
+        with patch('django.db.models.query.QuerySet.select_for_update') as select_for_update_func:
+            select_for_update_func.side_effect = DatabaseError()
+            response = self._post_request(post_data)
+            select_for_update_func.assert_called_once()
+
+        self.assertEqual(response.status_code, 400)
+        response_dic = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(response_dic['error'], 'invalid_grant')
 
     @override_settings(OIDC_TOKEN_EXPIRE=720,
                        OIDC_IDTOKEN_INCLUDE_CLAIMS=True)

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -18,6 +18,7 @@ try:
     from django.urls import reverse
 except ImportError:
     from django.core.urlresolvers import reverse
+from django.db import transaction
 from django.contrib.auth import logout as django_user_logout
 from django.http import JsonResponse, HttpResponse
 from django.shortcuts import render
@@ -207,9 +208,9 @@ class TokenView(View):
         token = TokenEndpoint(request)
 
         try:
-            token.validate_params()
-
-            dic = token.create_response_dic()
+            with transaction.atomic():
+                token.validate_params()
+                dic = token.create_response_dic()
 
             return TokenEndpoint.response(dic)
 


### PR DESCRIPTION
Enforce single use of authorization codes. When multiple simultaneous requests are issued to exchange the same code for an access token, only the first one can complete successfully.